### PR TITLE
Fix: Added JDK image, make module, and required dependencies to the script to resolve Polaris-Bridge job failure in the pipeline.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,8 +68,14 @@ generate_sbom:
       - main
 
 polaris_bridge:
-  stage: analysis
+  image: releng/base-gitlab-runner:jdk17-python3.11-git
   extends: .polaris_bridge
+  stage: analysis
+  before_script:
+    - |
+      apt-get update -y
+      apt-get install -y make
+      export DETECT_ACCURACY_REQUIRED=NONE
 
 pop_blackduck:
   image: us-docker.pkg.dev/cloudops-artifacts-prd/polaris/ember_cli:3.28.5-node_16.14


### PR DESCRIPTION
**Updates in GitLab CI File:**
- Updated the polaris_bridge job to use a new base image that includes Java.
- Added installation of make in the before_script.
- Set the DETECT_ACCURACY_REQUIRED environment variable to NONE.